### PR TITLE
Open the editor if it's closed

### DIFF
--- a/app.js
+++ b/app.js
@@ -299,6 +299,30 @@ app.controller('batchEditorController', function ($scope) {
         });
 
         if (!isEditorOpen) {
+            // Opens the editor if it's closed
+            const isMenuOpen = await callFunction(() => {
+                const menuButton = document.querySelector(".v-dialog--active #tab-details");
+                return !!menuButton;
+            });
+            if (!isMenuOpen) {
+                await callFunction(() => {
+                    const menuButton = document.querySelector('.v-btn.action-menu');
+                    menuButton.click();
+                });
+                await pause(1);
+            }
+            await callFunction(() => {
+                const editButton = document.querySelector('.v-btn.action-edit');
+                editButton.click();
+            });
+            await pause(1);
+        }
+
+        const isEditorOpenAgain = await callFunction(() => {
+            const element = document.querySelector(".v-dialog--active #tab-details");
+            return !!element;
+        });
+        if (!isEditorOpenAgain) {
             throw "Editor needs to be open with the first image/video";
         }
     }

--- a/app.js
+++ b/app.js
@@ -300,11 +300,11 @@ app.controller('batchEditorController', function ($scope) {
 
         if (!isEditorOpen) {
             // Opens the editor if it's closed
-            const isMenuOpen = await callFunction(() => {
-                const menuButton = document.querySelector(".v-dialog--active #tab-details");
-                return !!menuButton;
+            const isEditButtonVisible = await callFunction(() => {
+                const editButton = document.querySelector(".v-btn.action-edit");
+                return !!editButton;
             });
-            if (!isMenuOpen) {
+            if (!isEditButtonVisible) {
                 await callFunction(() => {
                     const menuButton = document.querySelector('.v-btn.action-menu');
                     menuButton.click();


### PR DESCRIPTION
This PR automatically opens the editor if it's closed by first clicking the count button (action menu), and then clicking the pencil button (edit button). It still throws the old error if the editor is not open afterwards.

Preview:

https://github.com/Blendan1/PhotoPrismBulkEditor/assets/5374768/2c894468-8ebd-4300-9d12-30343762cf9a

